### PR TITLE
SECURITY/improve-permissions-for-workflow-actions

### DIFF
--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -12,6 +12,8 @@ on:
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -1,0 +1,20 @@
+name: OSV-Scanner PR Scan
+
+# Change "main" to your default branch if you use a different name, i.e. "master"
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+
+permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # Only need to read contents
+  contents: read
+
+jobs:
+  scan-pr:
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.2.3"

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,4 +1,6 @@
 name: Publish to PyPI
+permissions:
+  contents: read
 
 on:
   release:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,6 +17,8 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  security-events: write
+  actions: read
 
 jobs:
   pylint:

--- a/.github/workflows/safety-scan.yml
+++ b/.github/workflows/safety-scan.yml
@@ -3,6 +3,7 @@ permissions:
   contents: read
   security-events: write
   actions: read
+  pull-requests: write
 
 on:
   push:

--- a/.github/workflows/safety-scan.yml
+++ b/.github/workflows/safety-scan.yml
@@ -1,4 +1,6 @@
 name: Safety Security Scan
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/safety-scan.yml
+++ b/.github/workflows/safety-scan.yml
@@ -1,6 +1,8 @@
 name: Safety Security Scan
 permissions:
   contents: read
+  security-events: write
+  actions: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/InfraMCP/atlassian-mcp-server/security/code-scanning/2](https://github.com/InfraMCP/atlassian-mcp-server/security/code-scanning/2)

To fix the problem, we need to add a `permissions` block to the workflow to explicitly set the required GitHub token permissions. The best way is to place `permissions:` at the root level of the workflow (just after the `name` and before `on:` or `jobs:`), so that it applies to all jobs unless overridden. For this workflow, setting `contents: read` is sufficient, since none of the steps require write access or interacting with other repository features. Therefore, insert the following block:

```yaml
permissions:
  contents: read
```

at the root, after the `name:` line and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
